### PR TITLE
added the option to restart a workflow (rerun all jobs)

### DIFF
--- a/R/workflows.R
+++ b/R/workflows.R
@@ -128,3 +128,11 @@ ga_workflow_dispatch = function(owner, repo = NULL, workflow_id, ref, ...) {
     endpoint = "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
     owner = owner, repo = repo, workflow_id = workflow_id, ref = ref, add_limit = FALSE, ...)
 }
+
+#' @rdname ga_workflows
+#' @export
+ga_workflow_rerun = function(owner, repo=NULL, workflow_id, ...) {
+  gh_helper(
+    endpoint = "POST /repos/{owner}/{repo}/actions/runs/{workflow_id}/rerun",
+    owner = owner, repo = repo, workflow_id = workflow_id, add_limit = FALSE, ...)
+}


### PR DESCRIPTION
This will restart a workflow in the same slot so it will keep the associated tag label intact. With the newly added delete-release action this should work.